### PR TITLE
Implement version category

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -5,6 +5,7 @@ status: ""
 date: {{ .Date }}
 draft: true
 gems: ["hanami"]
-tags: []
+tags: [""]
+versions: [""]
 ---
 

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ pygmentsuseclasses = true
 [taxonomies]
    tag = "tags"
    gem = "gems"
+   version = "versions"
 
 [permalinks]
   posts = "/:slug/"

--- a/content/posts/hanami-cli.md
+++ b/content/posts/hanami-cli.md
@@ -6,6 +6,7 @@ date: 2018-09-17T11:34:38+02:00
 draft: false
 gems: ["cli"]
 tags: ["command line"]
+versions: ["1.1"]
 ---
 
 Build your full featured Ruby CLI in a minute

--- a/content/posts/hanami-logger.md
+++ b/content/posts/hanami-logger.md
@@ -6,6 +6,7 @@ status: "Do you know Hanami::Logger is a full featured logger for Ruby? It works
 draft: false
 gems: ["utils"]
 tags: ["logging"]
+versions: ["1.0"]
 ---
 
 Do you know `Hanami::Logger` is a full featured logger for Ruby? It works with several IO targets, several log levels, it can output JSON, it offers time or file size rotation policies and it's able to filter (nested) sensitive data.

--- a/content/posts/hanami-router.md
+++ b/content/posts/hanami-router.md
@@ -6,6 +6,7 @@ status: "hanami-router is a fast, full featured, Rack compatible HTTP router for
 draft: false
 gems: ["router"]
 tags: ["http"]
+versions: ["1.0"]
 ---
 
 `hanami-router` is a fast, full featured, Rack compatible, HTTP router for Ruby.

--- a/content/posts/try-hanami.md
+++ b/content/posts/try-hanami.md
@@ -6,6 +6,7 @@ date: 2018-09-13T14:04:21+02:00
 draft: false
 gems: ["hanami"]
 tags: ["shell"]
+versions: ["1.0"]
 ---
 
 Do you want to try Hanami? Run this command:

--- a/themes/hanami/layouts/_default/single.html
+++ b/themes/hanami/layouts/_default/single.html
@@ -45,6 +45,9 @@
                     <h5 class="text-primary text-uppercase">{{ .Title }}</h5>
                     <p class="description mt-3">{{ .Content }}</p>
                     <div>
+                      {{ range .Params.versions }}
+                      <a href="/versions/{{ . }}"><span class="badge badge-pill badge-version">Hanami v{{ . }}+</span></a>
+                      {{ end }}
                       {{ range .Params.tags }}
                       <a href="/tags/{{ . | urlize }}"><span class="badge badge-pill badge-secondary">{{ . }}</span></a>
                       {{ end }}

--- a/themes/hanami/layouts/_default/taxonomy.html
+++ b/themes/hanami/layouts/_default/taxonomy.html
@@ -3,15 +3,16 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    {{ with .Description }}
-    <meta name="description"         content="Snippets for {{ $.Title }} gem: {{ . }}"> <!-- gem -->
-    <meta property="og:title"        content="{{ $.Title }} gem | {{ $.Site.Title }}" />
-    <meta property="og:description"  content="Snippets for {{ $.Title }} gem: {{ . }}" />
-    <meta name="twitter:title"       content="{{ $.Title }} gem | {{ $.Site.Title }}" />
-    <meta name="twitter:description" content="Snippets for {{ $.Title }} gem: {{ . }}" />
-    <meta property="og:image:alt"    content="Snippets for {{ $.Title }} gem: {{ . }}" />
+    {{ if eq .Type "gems" }}
+    <meta name="description"         content="Snippets for {{ .Title }} gem: {{ .Description }}"> <!-- gem -->
+    <meta property="og:title"        content="{{ .Title }} gem | {{ .Site.Title }}" />
+    <meta property="og:description"  content="Snippets for {{ .Title }} gem: {{ .Description }}" />
+    <meta name="twitter:title"       content="{{ .Title }} gem | {{ .Site.Title }}" />
+    <meta name="twitter:description" content="Snippets for {{ .Title }} gem: {{ .Description }}" />
+    <meta property="og:image:alt"    content="Snippets for {{ .Title }} gem: {{ .Description }}" />
     <title>{{ $.Title }} gem | {{ $.Site.Title }}</title>
-    {{ else }}
+    {{ end }}
+    {{ if eq .Type "tags" }}
     <meta name="description"         content="Hanami snippets tagged with {{ .Title }}"> <!-- tag -->
     <meta property="og:title"        content="{{ $.Title }} tag | {{ $.Site.Title }}" />
     <meta property="og:description"  content="Hanami snippets tagged with {{ .Title }}" />
@@ -19,6 +20,14 @@
     <meta name="twitter:description" content="Hanami snippets tagged with {{ .Title }}" />
     <meta property="og:image:alt"    content="Hanami snippets tagged with {{ .Title }}" />
     <title>{{ $.Title }} tag | {{ $.Site.Title }}</title>
+    {{ end }}
+    {{ if eq .Type "versions" }}
+    <meta name="description"         content="Snippets for Hanami version greater than {{ .Title }}"> <!-- version -->
+    <meta property="og:title"        content="Hanami v{{ $.Title }}+ | {{ $.Site.Title }}" />
+    <meta property="og:description"  content="Snippets for Hanami version greater than {{ .Title }}" />
+    <meta name="twitter:title"       content="Hanami v{{ $.Title }}+ | {{ $.Site.Title }}" />
+    <meta name="twitter:description" content="Snippets for Hanami version greater than {{ .Title }}" />
+    <meta property="og:image:alt"    content="Snippets for Hanami version greater than {{ .Title }}" />
     {{ end }}
 
     <meta property="og:url"          content="{{ .Permalink }}" />
@@ -56,6 +65,9 @@
                     <h6 class="text-primary text-uppercase">{{ .Title }}</h6>
                     <p class="description mt-3">{{ .Status | truncate 100 }}</p>
                     <div>
+                      {{ range .Params.versions }}
+                      <a href="/versions/{{ . }}"><span class="badge badge-pill badge-version">Hanami v{{ . }}+</span></a>
+                      {{ end }}
                       {{ range .Params.Tags }}
                       <a href="/tags/{{ . | urlize }}"><span class="badge badge-pill badge-secondary">{{ . }}</span></a>
                       {{ end }}

--- a/themes/hanami/layouts/index.html
+++ b/themes/hanami/layouts/index.html
@@ -47,6 +47,9 @@
                     <h6 class="text-primary text-uppercase">{{ .Title }}</h6>
                     <p class="description mt-3">{{ .Status | truncate 100 }}</p>
                     <div>
+                      {{ range .Params.versions }}
+                      <a href="/versions/{{ . }}"><span class="badge badge-pill badge-version">Hanami v{{ . }}+</span></a>
+                      {{ end }}
                       {{ range .Params.Tags }}
                       <a href="/tags/{{ . | urlize }}"><span class="badge badge-pill badge-secondary">{{ . }}</span></a>
                       {{ end }}

--- a/themes/hanami/layouts/partials/header.html
+++ b/themes/hanami/layouts/partials/header.html
@@ -81,7 +81,12 @@
         <div class="row">
           <div class="col-lg-6">
             {{ if eq .Kind "taxonomy" }}
-            <h1 class="display-3  text-white">{{ .Title | upper }} <!-- gem or tag -->
+            {{ if eq .Type "versions" }}
+            <h1 class="display-3 text-white">Hanami v{{ .Title }}+ <!-- version -->
+              <span>Snippets for Hanami version greater than {{ .Title }}.0</span>
+            {{ else }}
+            <h1 class="display-3 text-white">{{ .Title | upper }} <!-- gem or tag -->
+            {{ end }}
               {{ with .Params.description }}
               <span>{{ . }}</span>
               {{ end }}

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -106,6 +106,20 @@ a.text-primary:focus
     background: linear-gradient(87deg, #FF6138 0, #FFFF9D 100%) !important;
 }
 
+.badge-version
+{
+    color: #79BD8F;
+    background-color: rgba(255, 255, 157, .5);
+}
+.badge-version[href]:hover,
+.badge-version[href]:focus
+{
+    text-decoration: none;
+
+    color: #fff;
+    background-color: #00A388;
+}
+
 div.highlight > pre {
   padding: 1em;
 }


### PR DESCRIPTION
## Feature

Implement version category for snippets.

## Screenshots

Please note the new label that describes the version.

### Home page

![screen shot 2018-10-05 at 10 03 39](https://user-images.githubusercontent.com/5089/46523511-37138880-c886-11e8-86da-138ed17a7d61.png)

### Version page (new page)

![screen shot 2018-10-05 at 10 04 37](https://user-images.githubusercontent.com/5089/46523531-4561a480-c886-11e8-9383-60f6dfe4414e.png)

### Single page

![screen shot 2018-10-05 at 10 04 09](https://user-images.githubusercontent.com/5089/46523541-4c88b280-c886-11e8-8a59-4b05f265b751.png)

## Meta tags

Here's an example for `/versions/1.0`

```html
<meta name="description"         content="Snippets for Hanami version greater than 1.0">
<meta property="og:title"        content="Hanami v1.0+ | Hanami Snippets" />
<meta property="og:description"  content="Snippets for Hanami version greater than 1.0" />
<meta name="twitter:title"       content="Hanami v1.0+ | Hanami Snippets" />
<meta name="twitter:description" content="Snippets for Hanami version greater than 1.0" />
<meta property="og:image:alt"    content="Snippets for Hanami version greater than 1.0" />
```
